### PR TITLE
ca-certificates 2021.10.26

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2021.9.30" %}
-{% set sha256sum = "f524fc21859b776e18df01a87880efa198112214e13494275dbcbd9bcb71d976" %}
+{% set version = "2021.10.26" %}
+{% set sha256sum = "ae31ecb3c6e9ff3154cb7a55f017090448f88482f0e94ac927c0c67a1f33b9cf" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 


### PR DESCRIPTION
Update ca-certificates to 2021.10.26

Verified the latest cert bundle available from the curl team:
https://curl.se/ca/cacert-2021-10-26.pem - **130 Certificates**

Category: miniconda | subcategory: core | pkg_type: python
Popularity: 36517865 downloads - ca-certificates 2021.10.8 Certificates for use with other packages.
Version change: bump version number from 2021.9.30 to 2021.10.26
Requirements from conda-forge: https://github.com/conda-forge/ca-certificates-feedstock/blob/master/recipe/meta.yaml
license: MPL 2.0
Release date: 2021-10-26
Home url: https://curl.se/docs/caextract.html

The package ca-certificates is mentioned inside the packages:
gnutls | openssl | python-2.7 |

Actions:
1. No actions

Result:
- all-succeeded