### PR TITLE
ca-certificates 2022.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2021.10.26" %}
-{% set sha256sum = "ae31ecb3c6e9ff3154cb7a55f017090448f88482f0e94ac927c0c67a1f33b9cf" %}
+{% set version = "2022.2.1" %}
+{% set sha256sum = "1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ about:
   license: MPL-2.0
   license_file: LICENSE.txt
   summary: Certificates for use with other packages.
+  doc_url: https://github.com/curl/curl/blob/master/docs/SSLCERTS.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,10 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 3
+  number: 0
 
 test:
   requires:
-    - python <3.10
     - pip
   commands:
     - pip check


### PR DESCRIPTION
Update ca-certificates to 2022.2.1

home URL: https://curl.se/docs/caextract.html
Date: 2022-02-01
Certificates: 333

Actions:
1. Reset build number to `0`
2. Remove `python `from `test/requires`




