### PR TITLE
Update ca-certificates to 2022.4.26

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,9 @@ about:
   license_family: Other
   summary: Certificates for use with other packages.
   doc_url: https://github.com/curl/curl/blob/master/docs/SSLCERTS.md
-  dev_url: https://curl.se/docs/caextract.html # updates and sha256
+  dev_url: https://github.com/curl/curl/blob/master/scripts/mk-ca-bundle.pl
+  # mk-ca-bundle converts certdata.txt to cacert.pem
+  # https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ about:
   license_family: Other
   summary: Certificates for use with other packages.
   doc_url: https://github.com/curl/curl/blob/master/docs/SSLCERTS.md
+  dev_url: https://curl.se/docs/caextract.html # updates and sha256
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2022.3.29" %}
-{% set sha256sum = "1979e7fe618c51ed1c9df43bba92f977a0d3fe7497ffa2a5e80dfc559a1e5a29" %}
+{% set version = "2022.4.26" %}
+{% set sha256sum = "08df40e8f528ed283b0e480ba4bcdbfdd2fdcf695a7ada1668243072d80f8b6f" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 1
+  number: 0
 
 test:
   requires:
@@ -24,9 +24,10 @@ test:
     - pip check
 
 about:
-  home: https://github.com/conda-forge/ca-certificates-feedstock
+  home: https://curl.se/docs/caextract.html
   license: MPL-2.0
   license_file: LICENSE.txt
+  license_family: Other
   summary: Certificates for use with other packages.
   doc_url: https://github.com/curl/curl/blob/master/docs/SSLCERTS.md
 


### PR DESCRIPTION
# Changes

Changes:
- Update version to 2022.4.26
- Update metadata: home url, license family. Note: no dev_url here.

# Review Information

## Jira

https://anaconda.atlassian.net/browse/DSNC-4707

## Source

https://curl.se/docs/caextract.html


## License

LICENSE.txt


## Upstream Changes

https://curl.se/docs/caextract.html

## Issues

NA

## Pins and Requireds

NA

## Testing

Existing tests passed.


# Closing Comments

 Udpated to 2022.4.26