### PR TITLE
Update to 2022.07.19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2022.4.26" %}
-{% set sha256sum = "08df40e8f528ed283b0e480ba4bcdbfdd2fdcf695a7ada1668243072d80f8b6f" %}
+{% set version = "2022.07.19" %}
+{% set sha256sum = "6ed95025fba2aef0ce7b647607225745624497f876d74ef6ec22b26e73e9de77" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 


### PR DESCRIPTION
This is a new certificate release.
It consists of a single certificate file.

https://curl.se/docs/caextract.html