### PR TITLE
2023.05.30

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2023.01.10" %}
-{% set sha256sum = "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0" %}
+{% set version = "2023.05.30" %}
+{% set sha256sum = "5fadcae90aa4ae041150f8e2d26c37d980522cdb49f923fc1e1b5eb8d74e71ad" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,5 +43,3 @@ extra:
      - scopatz
   skip-lints:
     - missing_description
-    - missing_license_url
-    - missing_doc_source_url


### PR DESCRIPTION
# ca-certificates 2023.05.30

- Bump version and SHA

## Notes
- Linter is un-happy about the missing requirements section, but this is a binary re-pack and it's not needed. 