### PR TITLE
Update to 2023.8.22

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2023.05.30" %}
-{% set sha256sum = "5fadcae90aa4ae041150f8e2d26c37d980522cdb49f923fc1e1b5eb8d74e71ad" %}
+{% set version = "2023.08.22" %}
+{% set sha256sum = "23c2469e2a568362a62eecf1b49ed90a15621e6fa30e29947ded3436422de9b9" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -23,8 +23,5 @@ user_cert() {
 		exit 1
 	fi
 }
-#openssl -CAfile "${PREFIX}/ssl/cacert.pem" -CApath nosuchdir s_client -showcerts -connect www.google.com:443
-openssl s_client -CAfile "${PREFIX}/ssl/cacert.pem" -showcerts -connect www.google.com:443
-user_cert $?
 curl --cacert "${PREFIX}/ssl/cacert.pem" https://www.google.com
 user_cert $?


### PR DESCRIPTION
Simply updating to the latest. This is a critical package for our ecosystem.

I also removed the test that was running `openssl s_client` because it was causing issues with OpenSSL 3. This is due to a change in behavior on the OpenSSL 3 side. After some discussions, we think it is safe to solely rely on curl for our tests.