### PR TITLE
PKG-3652: version bump 2023.12.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2023.08.22" %}
-{% set sha256sum = "23c2469e2a568362a62eecf1b49ed90a15621e6fa30e29947ded3436422de9b9" %}
+{% set version = "2023.12.12" %}
+{% set sha256sum = "ccbdfc2fe1a0d7bbbb9cc15710271acf1bb1afe4c8f1725fe95c4c7733fcbe5a" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 


### PR DESCRIPTION
ca-certificates: 2023.12.12

**Destination channel:** defaults

### Links

- [PKG-3652](https://anaconda.atlassian.net/browse/PKG-3652) 

### Explanation of changes:

- New version


[PKG-3652]: https://anaconda.atlassian.net/browse/PKG-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ