### PR TITLE
Noarch build to incorporate ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,7 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 1
-  noarch: generic
+  number: 0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 0
+  number: 1
+  noarch: generic
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,3 +44,4 @@ extra:
      - scopatz
   skip-lints:
     - missing_description
+    - missing_section


### PR DESCRIPTION
ca-certificates 2023.12.12

**Destination channel:** defaults

### Links

- [PKG-3836](https://anaconda.atlassian.net/browse/PKG-3836)
- [Upstream repository]()

### Explanation of changes:

- Make noarch
- Raise build number
- skip missing_section lint


[PKG-3836]: https://anaconda.atlassian.net/browse/PKG-3836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ