### PR TITLE
ca-certificates 2024.12.31

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2024.11.26" %}
-{% set sha256sum = "bb1782d281fe60d4a2dcf41bc229abe3e46c280212597d4abcc25bddf667739b" %}
+{% set version = "2024.12.31" %}
+{% set sha256sum = "a3f328c21e39ddd1f2be1cea43ac0dec819eaa20a90425d7da901a11531b3aa5" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6696](https://anaconda.atlassian.net/browse/PKG-6696)
- [Upstream repository](https://github.com/curl/curl/blob/master/scripts/mk-ca-bundle.pl)
- [Upstream changelog/diff](https://curl.se/docs/caextract.html)


### Explanation of changes:

- Update version


[PKG-6696]: https://anaconda.atlassian.net/browse/PKG-6696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ