### PR TITLE
ca-certificates 2025.9.9 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2025.7.15" %}
-{% set sha256sum = "7430e90ee0cdca2d0f02b1ece46fbf255d5d0408111f009638e3b892d6ca089c" %}
+{% set version = "2025.9.9" %}
+{% set sha256sum = "f290e6acaf904a4121424ca3ebdd70652780707e28e8af999221786b86bb1975" %}
 
 {% set reldate = "{:d}-{:02d}-{:02d}".format(*(version.split(".") | map("int"))) %}
 


### PR DESCRIPTION
ca-certificates 2025.9.9 

**Destination channel:** Defaults

### Links

- [PKG-9605]
- dev_url:        https://github.com/curl/curl/blob/master/scripts/mk-ca-bundle.pl/tree/
- conda_forge:    https://github.com/conda-forge/ca-certificates-feedstock
- pypi:           https://www.google.com/
- pypi inspector: https://www.google.com/

### Explanation of changes:

- new version number
