### PR TITLE
Fix regex pattern

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -2,4 +2,4 @@ anaconda_config_version: 1
 upstream_sources:
   - webpage:
       url: https://curl.haxx.se/docs/caextract.html
-      regex: (?:.*)cacert-(\d+)-(\d+)-(\d+)\.pem
+      regex: (?:.*)cacert-([\d-]+)\.pem


### PR DESCRIPTION
```
python -m scripts.one_offs.feedstock_config_generator.anaconda_yaml_to_nvchecker \
  --yaml "$HOME/src/aggregate/ca-certificates-feedstock/anaconda.yaml" \
  -o /tmp/ca-certificates.toml \
  -n ca-certificates \
  --entry 0 \
  --run -e ca-certificates
anaconda-yaml-to-nvchecker: input=file path=/Users/skupr/src/aggregate/ca-certificates-feedstock/anaconda.yaml
anaconda-yaml-to-nvchecker: const: merged URL_WEBPAGE_MISSING_REGEX_EXCEPTIONS['ca-certificates'] into nvchecker regex row
anaconda-yaml-to-nvchecker: process: anaconda.yaml upstream_sources[0] type='webpage' -> nvchecker TOML section [ca-certificates] (list_len=1)
anaconda-yaml-to-nvchecker:   url = 'https://curl.se/docs/caextract.html'
anaconda-yaml-to-nvchecker:   regex (26 chars): '(?:.*)cacert-([\\d-]+)\\.pem'
anaconda-yaml-to-nvchecker: output: wrote /private/tmp/ca-certificates.toml
anaconda-yaml-to-nvchecker: run: nvchecker -c /tmp/ca-certificates.toml -e ca-certificates
[I 04-09 00:08:06.154 core:416] ca-certificates: updated to 2026-03-19
```